### PR TITLE
🧹 chore: remove pre-defined information

### DIFF
--- a/bryan_snaily/config.lua
+++ b/bryan_snaily/config.lua
@@ -5,7 +5,7 @@ Config.Defaults = {
 }
 
 Config.API = {
-    URL = 'https://api-test.swiftpeakhosting.co.uk/v1/',
-    TOKEN = 'sng_4TiV5Zuszyn9iDRQhnOpCXvrqPbvP9-VTF4SEl2uB5zYqXm1OkHIlD3R',
-    TOKEN_HEADER_NAME = 'snaily-cad-api-token',
+    URL = '[API_URL]',
+    TOKEN = '[API_TOKEN]',
+    TOKEN_HEADER_NAME = 'snaily-cad-api-token', -- DO NOT CHANGE
 }


### PR DESCRIPTION
It's probably best to remove the pre-defined information. I don't think you ideally want people downloading this resource and making calls to your CAD's API 😉